### PR TITLE
DKAN Custom Solr Server functionality

### DIFF
--- a/dkan_custom_solr.info
+++ b/dkan_custom_solr.info
@@ -1,0 +1,5 @@
+name = DKAN Custom Solr Server
+description = Solr Search Settings for Local Environments.
+core = 7.x
+package = DKAN
+dependencies[] = search_api_solr

--- a/dkan_custom_solr.install
+++ b/dkan_custom_solr.install
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @file
+ * Code for DKAN Custom Solr Server.
+*/
+
+/**
+ * Implements hook_disable().
+ */
+function dkan_custom_solr_disable() {
+  // Delete dkan_custom_solr server
+  if ($server = dkan_custom_solr_query_dkan_server('dkan_custom_solr')) {
+    entity_delete('search_api_server', array_keys($server)[0]);
+  }
+}

--- a/dkan_custom_solr.make
+++ b/dkan_custom_solr.make
@@ -1,0 +1,4 @@
+api = 2
+core = 7.x
+
+projects[search_api_solr][version] = 1.14

--- a/dkan_custom_solr.module
+++ b/dkan_custom_solr.module
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @file
+ * Code for the DKAN Custom Solr Server.
+ */
+
+/**
+ * Queries the search_api_server for dkan_acquia_solr.
+ */
+function dkan_custom_solr_query_dkan_server($server) {
+  $query = new EntityFieldQuery();
+  $result = $query->entityCondition('entity_type', 'search_api_server', '=')
+    ->propertyCondition('machine_name', $server)
+    ->execute();
+  if (isset($result['search_api_server'])) {
+    return $result['search_api_server'];
+  }
+  return FALSE;
+}
+
+/*
+ * Implements hook_environment_switch.
+ */
+function dkan_custom_solr_environment_switch($target_env, $source_env) {
+  features_revert_module('dkan_dataset_groups');
+  features_revert_module('dkan_sitewide_search_db');
+  features_revert_module('dkan_data_story');
+}
+
+/**
+ * Implements hook_default_search_api_server().
+ */
+function dkan_custom_solr_default_search_api_server() {
+  return array(
+    'dkan_custom_solr' => entity_create(
+      'search_api_server',
+      array(
+        'name' => 'DKAN Custom Solr',
+        'machine_name' => 'dkan_custom_solr',
+        'description' => 'Custom Search API Solr server.',
+        'class' => 'search_api_solr_service',
+        'enabled' => 1,
+        'options' => array(
+          'port' => 8983,
+          'host' => 'solr',
+          'scheme' => 'http',
+          'path' => '/solr',
+          'http_user' => '',
+          'http_pass' => '',
+          'http_method' => 'AUTO',
+          'clean_ids' => true,
+          'site_hash' => false,
+        ),
+      )
+    ),
+  );
+}
+
+/**
+ * Implements hook_default_search_api_index_alter().
+ */
+function dkan_custom_solr_default_search_api_index_alter(array &$defaults) {
+  // List of the possible search api indexes.
+  $index_list = array(
+    "stories_index",
+    "datasets",
+    "groups_di",
+  );
+  foreach ($index_list as $index) {
+    if (isset($defaults[$index])) {
+      $defaults[$index]->server = 'dkan_custom_solr';
+    }
+  }
+}


### PR DESCRIPTION
## User story

As a developer I want to use a Solr server to build and develop DKAN locally.

## QA Steps

- [ ] Add this module and search_api_solr to your codebase.
- [ ] Enable new module dkan_custom_solr.
- Go to `admin/config/search/search_api` and confirm:
  - [ ] there is a server called `DKAN Custom Solr`
  - [ ] the indexes are stored in the `DKAN Custom Solr` server.
- [ ] Reindex the site.
- [ ] Go to search page and confirm it works as expected.
- [ ] Go to groups page and confirm it works as expected.
- [ ] Confirm documentation is accurate.